### PR TITLE
Fixed errors and some change for frontend files

### DIFF
--- a/FirstApp.py
+++ b/FirstApp.py
@@ -1,14 +1,16 @@
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer, SimpleHTTPRequestHandler
 import os
 import json
 import shutil
+import mimetypes
 
 class MyHttpRequestHandler(BaseHTTPRequestHandler):
 
     def createFolder(self, dir, name):
-            os.mkdir(os.path.join(dir, name))
+        os.mkdir(os.path.join(dir, name))
 
     def deleteFolder(self, dir, name):
+        if(name != 'MainFolder'):
             shutil.rmtree(os.path.join(dir, name))
 
     def processParamsGet(self, params, dir):
@@ -19,18 +21,42 @@ class MyHttpRequestHandler(BaseHTTPRequestHandler):
             if type == "delete":
                 self.deleteFolder(dir, name)
 
-    def processNonParamsGet(self, dir):
+    def containsSysFile(self, dir):
+        arr = dir.split('/')
+        for str in arr:
+            if(str == 'MainFolder'):
+                return True
+        return False
+            
+    def processNonParamsGet(self, dir, mtype):
         if os.path.isdir(dir):
             list = os.listdir(dir)
             json_data = json.dumps(list)
             self.send_response(200)
+            self.end_headers()
+            self.wfile.write(bytes(json_data, 'utf-8'))
         if os.path.isfile(dir):
             path = os.path.normpath(dir)
             json_data = open(path, 'rb').read()
             self.send_response(200)
-            self.send_header('Content-Disposition', 'attachment')
-        self.end_headers()
-        self.wfile.write(bytes(json_data,'utf-8'))
+            self.send_header('Content-Type', mtype)
+            if ((mtype != 'text/css') & (mtype != 'text/javascript')) | (self.containsSysFile(dir) == False):
+                self.send_header('Content-Disposition', 'attachment')
+            self.end_headers()
+            self.wfile.write(json_data)
+
+    def openHtml(self, dir):
+        path = os.path.join(dir, 'index.html')
+        if os.path.isfile(path):
+            normPath = os.path.normpath(path)
+            data = open(path, 'rb').read()
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(data)
+
+    def guess_type(self, dir):
+        type = mimetypes.guess_type(dir)
+        return type[0]
 
     def do_GET(self):
         SERV_DIR = "C:/Users/lmusic/Desktop/MyServFolder"
@@ -47,8 +73,11 @@ class MyHttpRequestHandler(BaseHTTPRequestHandler):
                 dir = os.path.join(dir, item)
         if params:
             self.processParamsGet(params, dir)
-
-        self.processNonParamsGet(dir)
+        newtype = self.guess_type(dir)
+        if(dir == SERV_DIR):
+            self.openHtml(dir)
+        else:
+            self.processNonParamsGet(dir, newtype)
 
 
 server_adress = ("", 8000)


### PR DESCRIPTION
1. TypeError: encoding without a string argument - was fixed.
2. Now only MainFolder's tree enable for clients 
3. Mimetypes for returned files was added
4. Now if cliet go in to the root of serv folder, index.html will open as web page (NOT download)